### PR TITLE
Fix: Correct DonetickChoreCompleteButton constructor call

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -36,7 +36,7 @@ async def async_setup_entry(
     for chore in coordinator.data:
         sensor = DonetickChoreSensor(name, chore, coordinator)
         button = DonetickChoreCompleteButton(
-            chore["id"], chore["name"], api_url, api_token, sensor
+            chore["id"], chore["name"], api_url, api_token
         )
         sensors.append(sensor)
         buttons.append(button)


### PR DESCRIPTION
This commit fixes a TypeError that occurred because the DonetickChoreCompleteButton constructor was being called with an extra argument in sensor.py. The unused sensor argument has been removed from the constructor call to match its definition in button.py.