### PR TITLE
Fix: Use correct API endpoint for fetching chores

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,7 +27,7 @@ class DonetickDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Fetch data from API endpoint."""
-        url = f"{self.api_url}/chores"  # Assuming /chores is the endpoint
+        url = self.api_url  # The API URL already includes the full path
         headers = {"secretkey": self.api_token}
 
         try:


### PR DESCRIPTION
Corrects the `_async_update_data` method in `DonetickDataUpdateCoordinator` to use the `api_url` directly as the endpoint for fetching chores, instead of appending "/chores" to it.

This change is based on your feedback indicating that the `api_url` provided during setup is the complete endpoint for the chore list.